### PR TITLE
Update required cmake version

### DIFF
--- a/costmap_cspace_rviz_plugins/CMakeLists.txt
+++ b/costmap_cspace_rviz_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.3)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(costmap_cspace_rviz_plugins)
 
 set(PACKAGE_DEPENDS

--- a/neonavigation_rviz_plugins/CMakeLists.txt
+++ b/neonavigation_rviz_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(neonavigation_rviz_plugins)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/trajectory_tracker_rviz_plugins/CMakeLists.txt
+++ b/trajectory_tracker_rviz_plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.1...3.26)
 project(trajectory_tracker_rviz_plugins)
 
 set(CATKIN_DEPENDS


### PR DESCRIPTION
Allow to use cmake compatibility mode up to 3.26 to avoid error/warning on the latest cmake.
CMake 4.0 dropped 3.5 and marked 3.10 as deprecated.